### PR TITLE
feat: allow Symfony 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.3', '8.4']
-        symfony: ['6.4', '7.3']
+        symfony: ['6.4', '7.3', '8.0']
       fail-fast: false
     steps:
       -   name: cancel

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
         "dropsolid/langfuse-php-sdk": "^1.2",
         "lingoda/ai-bundle": "^1.2",
         "psr/log": "^3.0",
-        "symfony/cache": "^6.4|^7.0",
-        "symfony/clock": "^6.4|^7.0",
-        "symfony/config": "^6.4|^7.0",
-        "symfony/console": "^6.4|^7.0",
-        "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/expression-language": "^6.4|^7.0",
-        "symfony/http-client": "^6.4|^7.0",
-        "symfony/http-foundation": "^6.4|^7.0",
-        "symfony/http-kernel": "^6.4|^7.0",
+        "symfony/cache": "^6.4|^7.0|^8.0",
+        "symfony/clock": "^6.4|^7.0|^8.0",
+        "symfony/config": "^6.4|^7.0|^8.0",
+        "symfony/console": "^6.4|^7.0|^8.0",
+        "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+        "symfony/expression-language": "^6.4|^7.0|^8.0",
+        "symfony/http-client": "^6.4|^7.0|^8.0",
+        "symfony/http-foundation": "^6.4|^7.0|^8.0",
+        "symfony/http-kernel": "^6.4|^7.0|^8.0",
         "webmozart/assert": "^1.11"
     },
     "suggest": {
@@ -34,7 +34,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "symfony/messenger": "^6.4|^7.0",
+        "symfony/messenger": "^6.4|^7.0|^8.0",
         "symplify/easy-coding-standard": "^12.0"
     },
     "config": {
@@ -57,7 +57,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "require": "^6.4|^7.0"
+            "require": "^6.4|^7.0|^8.0"
         }
     }
 }

--- a/src/LingodaLangfuseBundle.php
+++ b/src/LingodaLangfuseBundle.php
@@ -27,7 +27,6 @@ class LingodaLangfuseBundle extends AbstractBundle
         /** @var ArrayNodeDefinition $rootNode */
         $rootNode = $definition->rootNode();
 
-        /** @phpstan-ignore-next-line */
         $rootNode
             ->children()
                 // Connection settings


### PR DESCRIPTION
Adds `|^8.0` to all Symfony constraints. Removes stale PHPStan ignore.

279 tests pass. All hooks pass.

Release as **1.2.0**.